### PR TITLE
Add expense reporting month functionality and related database updates

### DIFF
--- a/add_assigned_month.sql
+++ b/add_assigned_month.sql
@@ -1,0 +1,38 @@
+-- Add expenses_assigned_month column to expenses table
+ALTER TABLE public.expenses ADD COLUMN expenses_assigned_month TEXT;
+
+-- Add a comment to explain the purpose of this field
+COMMENT ON COLUMN public.expenses.expenses_assigned_month IS 'The month this expense is assigned to for reporting and UI display, regardless of payment date. Format: "Month YYYY"';
+
+-- Initially populate based on date_from (service start date) as default
+UPDATE public.expenses 
+SET expenses_assigned_month = 
+  CASE 
+    WHEN date_from IS NOT NULL THEN to_char(date_from, 'Month YYYY')
+    WHEN date_to IS NOT NULL THEN to_char(date_to, 'Month YYYY')
+    ELSE to_char(created_at, 'Month YYYY')
+  END;
+
+-- Create a function to set a default value for new expenses
+CREATE OR REPLACE FUNCTION set_default_assigned_month()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Only set a default if expenses_assigned_month is NULL
+  IF NEW.expenses_assigned_month IS NULL THEN
+    NEW.expenses_assigned_month := 
+      CASE 
+        WHEN NEW.date_from IS NOT NULL THEN to_char(NEW.date_from, 'Month YYYY')
+        WHEN NEW.date_to IS NOT NULL THEN to_char(NEW.date_to, 'Month YYYY')
+        ELSE to_char(NEW.created_at, 'Month YYYY')
+      END;
+  END IF;
+  
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create a trigger to set the default value for new or updated expenses
+CREATE TRIGGER default_assigned_month_trigger
+BEFORE INSERT OR UPDATE ON public.expenses
+FOR EACH ROW
+EXECUTE FUNCTION set_default_assigned_month(); 

--- a/add_assigned_month_simple.sql
+++ b/add_assigned_month_simple.sql
@@ -1,0 +1,5 @@
+-- Add expenses_assigned_month column to expenses table
+ALTER TABLE public.expenses ADD COLUMN expenses_assigned_month TEXT;
+
+-- Add a comment to explain the purpose of this field
+COMMENT ON COLUMN public.expenses.expenses_assigned_month IS 'The month this expense is assigned to for reporting and UI display, regardless of payment date. Format: "Month YYYY"'; 

--- a/add_expense_month_migration.sql
+++ b/add_expense_month_migration.sql
@@ -1,0 +1,21 @@
+-- Add expense_month column to expenses table
+ALTER TABLE public.expenses ADD COLUMN expense_month TEXT;
+
+-- Update existing records to populate expense_month based on service period (date_from)
+-- This prioritizes the month the service was FOR, not when it was paid
+UPDATE public.expenses 
+SET expense_month = 
+  CASE 
+    -- For expenses with a date range, use the starting date (date_from) as the canonical month
+    -- This represents the month the service was FOR (like April admin fees)
+    WHEN date_from IS NOT NULL THEN to_char(date_from, 'Month YYYY')
+    -- For expenses without date ranges, fall back to date_to or created_at
+    WHEN date_to IS NOT NULL THEN to_char(date_to, 'Month YYYY')
+    ELSE to_char(created_at, 'Month YYYY')
+  END;
+
+-- Add a comment to explain the purpose of this field
+COMMENT ON COLUMN public.expenses.expense_month IS 'The canonical month this expense belongs to for reporting/UI display (Month YYYY format). Represents the month the service was FOR, not when it was paid.';
+
+-- Make this field mandatory for future records
+ALTER TABLE public.expenses ALTER COLUMN expense_month SET NOT NULL; 

--- a/add_expense_month_trigger.sql
+++ b/add_expense_month_trigger.sql
@@ -1,0 +1,25 @@
+-- Create a function to set expense_month based on the month the service was FOR
+CREATE OR REPLACE FUNCTION set_expense_month()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Set expense_month based on service period priority:
+  -- date_from is preferred since it indicates when the service period started
+  NEW.expense_month := 
+    CASE 
+      -- For expenses with a date range, use the starting date (date_from) as the canonical month
+      -- This represents the month the service was FOR (like April admin fees)
+      WHEN NEW.date_from IS NOT NULL THEN to_char(NEW.date_from, 'Month YYYY')
+      -- For expenses without date_from, fall back to date_to or created_at
+      WHEN NEW.date_to IS NOT NULL THEN to_char(NEW.date_to, 'Month YYYY')
+      ELSE to_char(NEW.created_at, 'Month YYYY')
+    END;
+  
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create a trigger to automatically set expense_month for new or updated records
+CREATE TRIGGER set_expense_month_trigger
+BEFORE INSERT OR UPDATE ON public.expenses
+FOR EACH ROW
+EXECUTE FUNCTION set_expense_month(); 

--- a/add_manual_override.sql
+++ b/add_manual_override.sql
@@ -1,0 +1,28 @@
+-- Add a column for manually overriding the expense_month calculation
+ALTER TABLE public.expenses ADD COLUMN expense_month_override TEXT;
+
+-- Update the trigger function to respect manual overrides
+CREATE OR REPLACE FUNCTION set_expense_month()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- If an override is provided, use that as the expense_month
+  IF NEW.expense_month_override IS NOT NULL THEN
+    NEW.expense_month := NEW.expense_month_override;
+  ELSE
+    -- Otherwise use the automatic calculation based on service period
+    NEW.expense_month := 
+      CASE 
+        -- For expenses with a date range, use the starting date (date_from) 
+        WHEN NEW.date_from IS NOT NULL THEN to_char(NEW.date_from, 'Month YYYY')
+        -- For expenses without date_from, fall back to date_to or created_at
+        WHEN NEW.date_to IS NOT NULL THEN to_char(NEW.date_to, 'Month YYYY')
+        ELSE to_char(NEW.created_at, 'Month YYYY')
+      END;
+  END IF;
+  
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Add a comment to explain the override field
+COMMENT ON COLUMN public.expenses.expense_month_override IS 'Manual override for expense_month. Use this to force an expense to appear in a specific month report regardless of its dates.'; 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "react-dom": "^18.2.0",
     "recharts": "^2.13.3",
     "shadcn-ui": "^0.2.3",
-    "tailwind-merge": "^2.5.4",
+    "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,7 +10,7 @@
     --card-foreground: 0 0% 3.9%;
     --popover: 0 0% 100%;
     --popover-foreground: 0 0% 3.9%;
-    --primary: 0 0% 9%;
+    --primary: 270 95% 75%;
     --primary-foreground: 0 0% 98%;
     --secondary: 0 0% 96.1%;
     --secondary-foreground: 0 0% 9%;
@@ -22,7 +22,7 @@
     --destructive-foreground: 0 0% 98%;
     --border: 0 0% 89.8%;
     --input: 0 0% 89.8%;
-    --ring: 0 0% 3.9%;
+    --ring: 270 95% 75%;
     --chart-1: 12 76% 61%;
     --chart-2: 173 58% 39%;
     --chart-3: 197 37% 24%;
@@ -32,12 +32,12 @@
 
     --sidebar-background: 0 0% 98%;
     --sidebar-foreground: 240 5.3% 26.1%;
-    --sidebar-primary: 240 5.9% 10%;
+    --sidebar-primary: 270 95% 75%;
     --sidebar-primary-foreground: 0 0% 98%;
     --sidebar-accent: 240 4.8% 95.9%;
     --sidebar-accent-foreground: 240 5.9% 10%;
     --sidebar-border: 220 13% 91%;
-    --sidebar-ring: 217.2 91.2% 59.8%;
+    --sidebar-ring: 270 95% 75%;
   }
   .dark {
     --background: 0 0% 3.9%;
@@ -46,7 +46,7 @@
     --card-foreground: 0 0% 98%;
     --popover: 0 0% 3.9%;
     --popover-foreground: 0 0% 98%;
-    --primary: 0 0% 98%;
+    --primary: 270 95% 75%;
     --primary-foreground: 0 0% 9%;
     --secondary: 0 0% 14.9%;
     --secondary-foreground: 0 0% 98%;
@@ -58,7 +58,7 @@
     --destructive-foreground: 0 0% 98%;
     --border: 0 0% 14.9%;
     --input: 0 0% 14.9%;
-    --ring: 0 0% 83.1%;
+    --ring: 270 95% 75%;
     --chart-1: 220 70% 50%;
     --chart-2: 160 60% 45%;
     --chart-3: 30 80% 55%;
@@ -67,12 +67,12 @@
 
     --sidebar-background: 240 5.9% 10%;
     --sidebar-foreground: 240 4.8% 95.9%;
-    --sidebar-primary: 224.3 76.3% 48%;
+    --sidebar-primary: 270 95% 75%;
     --sidebar-primary-foreground: 0 0% 100%;
     --sidebar-accent: 240 3.7% 15.9%;
     --sidebar-accent-foreground: 240 4.8% 95.9%;
     --sidebar-border: 240 3.7% 15.9%;
-    --sidebar-ring: 217.2 91.2% 59.8%;
+    --sidebar-ring: 270 95% 75%;
   }
 }
 

--- a/src/components/ExpensesHeader.tsx
+++ b/src/components/ExpensesHeader.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { ZapIcon } from "lucide-react";
+
 interface ExpensesHeaderProps {
   selectedMonth: string | null;
   displayMonth: string | null;
@@ -14,13 +17,23 @@ export default function ExpensesHeader({
   }
 
   return (
-    <div className="bg-blue-50 p-4 my-4 rounded-lg text-blue-800">
-      <p className="text-sm font-medium">
-        Mostrando gastos de: <span className="font-bold">{displayMonth}</span>
-      </p>
-      <p className="text-xs text-blue-600">
-        Los gastos siempre corresponden al mes anterior al seleccionado
-      </p>
+    <div className="space-y-4">
+      <Alert className="bg-primary/10 border-primary/20">
+        <ZapIcon className="h-4 w-4 text-gray-800" />
+        <AlertTitle className="text-gray-800">
+          Mostrando gastos de: <span className="font-bold">{displayMonth}</span>
+        </AlertTitle>
+        <AlertDescription className="text-gray-700">
+          Los gastos siempre corresponden al mes anterior al seleccionado
+        </AlertDescription>
+      </Alert>
+
+      <Alert className="bg-primary/10 border-primary/20">
+        <ZapIcon className="h-4 w-4 text-gray-800" />
+        <AlertDescription className="text-gray-700">
+          Los gastos de limpieza se pagan a mes vencido
+        </AlertDescription>
+      </Alert>
     </div>
   );
 }

--- a/src/components/FinExpenseBreakdown.tsx
+++ b/src/components/FinExpenseBreakdown.tsx
@@ -17,7 +17,13 @@ export default function ExpenseBreakdown({
 }: ExpenseBreakdownProps) {
   // Check if data is defined
   if (!expenses || expenses.length === 0) {
-    return <p>No se encontraron gastos comunes.</p>;
+    return (
+      <CardWrapper title="Detalle de gastos ↗️">
+        <div className="p-4 text-center">
+          <p className="text-gray-500">No se encontraron gastos comunes.</p>
+        </div>
+      </CardWrapper>
+    );
   }
 
   // Debug logging

--- a/src/components/charts/BarChart.tsx
+++ b/src/components/charts/BarChart.tsx
@@ -53,7 +53,15 @@ const chartConfig = {
 export default function BarChartComponent({ expenses }: ExpenseChartProps) {
   // Check if data is defined
   if (!expenses || expenses.length === 0) {
-    return <p>No hay información para mostrar la gráfica.</p>;
+    return (
+      <CardWrapper title="Gráfica de gastos ↗️">
+        <div className="p-4 text-center h-[350px] flex items-center justify-center">
+          <p className="text-gray-500">
+            No hay información para mostrar la gráfica.
+          </p>
+        </div>
+      </CardWrapper>
+    );
   }
 
   // Function to generate a color based on provider name (consistent hash)

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from "@/helpers/utils";
+import { cn } from "@/lib/utils"
 
 const alertVariants = cva(
   "relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground",
@@ -17,7 +17,7 @@ const alertVariants = cva(
       variant: "default",
     },
   }
-);
+)
 
 const Alert = React.forwardRef<
   HTMLDivElement,
@@ -29,8 +29,8 @@ const Alert = React.forwardRef<
     className={cn(alertVariants({ variant }), className)}
     {...props}
   />
-));
-Alert.displayName = "Alert";
+))
+Alert.displayName = "Alert"
 
 const AlertTitle = React.forwardRef<
   HTMLParagraphElement,
@@ -41,8 +41,8 @@ const AlertTitle = React.forwardRef<
     className={cn("mb-1 font-medium leading-none tracking-tight", className)}
     {...props}
   />
-));
-AlertTitle.displayName = "AlertTitle";
+))
+AlertTitle.displayName = "AlertTitle"
 
 const AlertDescription = React.forwardRef<
   HTMLParagraphElement,
@@ -53,7 +53,7 @@ const AlertDescription = React.forwardRef<
     className={cn("text-sm [&_p]:leading-relaxed", className)}
     {...props}
   />
-));
-AlertDescription.displayName = "AlertDescription";
+))
+AlertDescription.displayName = "AlertDescription"
 
-export { Alert, AlertTitle, AlertDescription };
+export { Alert, AlertTitle, AlertDescription }

--- a/src/helpers/fetchExpenses.ts
+++ b/src/helpers/fetchExpenses.ts
@@ -55,6 +55,7 @@ const fallbackData: DashboardData = {
       description: "Fallback data",
       building_id: "cd4d2980-8c5e-444e-9840-6859582c0ea5",
       building_address: "Ejido 123",
+      expense_reporting_month: dayjs().format("YYYY-MM"),
     },
   ],
 };

--- a/src/helpers/filterUniqueMonth.tsx
+++ b/src/helpers/filterUniqueMonth.tsx
@@ -6,26 +6,48 @@ import { Expense } from "@/types/expense";
 export const filterUniqueMonth = (expenses: Expense[]): string[] => {
   const months = new Set<string>();
 
-  // Go through each expense
+  // Go through each expense and use its canonical expense_reporting_month
   expenses.forEach((expense) => {
-    // If it has a created_at date, add that month
-    if (expense.created_at) {
-      const createdAtMonth = dayjs(expense.created_at).format("MMMM YYYY");
-      months.add(createdAtMonth);
+    // If expense has the designated expense_reporting_month field, use that
+    if (expense.expense_reporting_month) {
+      // Convert from YYYY-MM format to Month YYYY format
+      const [year, month] = expense.expense_reporting_month.split("-");
+      if (year && month) {
+        // Create a date for the 1st day of the month, then format to "Month YYYY"
+        const formattedMonth = dayjs(`${year}-${month}-01`).format("MMMM YYYY");
+        months.add(formattedMonth);
+      } else {
+        // If the format is unexpected, just add it as is
+        months.add(expense.expense_reporting_month);
+      }
     }
+    // Fallback to old method if expense_reporting_month is not available
+    else {
+      // If it has a created_at date, add that month
+      if (expense.created_at) {
+        const createdAtMonth = dayjs(expense.created_at).format("MMMM YYYY");
+        months.add(createdAtMonth);
+      }
 
-    // If it has date_from, add that month
-    if (expense.date_from) {
-      const dateFromMonth = dayjs(expense.date_from).format("MMMM YYYY");
-      months.add(dateFromMonth);
-    }
+      // If it has date_from, add that month
+      if (expense.date_from) {
+        const dateFromMonth = dayjs(expense.date_from).format("MMMM YYYY");
+        months.add(dateFromMonth);
+      }
 
-    // If it has date_to, add that month
-    if (expense.date_to) {
-      const dateToMonth = dayjs(expense.date_to).format("MMMM YYYY");
-      months.add(dateToMonth);
+      // If it has date_to, add that month
+      if (expense.date_to) {
+        const dateToMonth = dayjs(expense.date_to).format("MMMM YYYY");
+        months.add(dateToMonth);
+      }
     }
   });
+
+  // Add the current month if not already included
+  const currentMonth = dayjs().format("MMMM YYYY");
+  if (!months.has(currentMonth)) {
+    months.add(currentMonth);
+  }
 
   // Convert to array and sort chronologically
   return Array.from(months).sort((a, b) =>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,12 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+/**
+ * Combines multiple class names using clsx and ensures proper Tailwind CSS
+ * class merging with tailwind-merge.
+ *
+ * This utility is used throughout shadcn/ui components.
+ */
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/src/types/expense.ts
+++ b/src/types/expense.ts
@@ -20,6 +20,7 @@ export interface Expense {
   created_at: string | null; // When the record was created in ISO format
   date_from?: string | null; // Optional start date of the expense period
   date_to?: string | null; // Optional end date of the expense period
+  expense_reporting_month: string; // Format: YYYY-MM for the month this expense should be reported in
   provider_name: string; // Name of the provider from the providers table
   description: string; // Detailed description of the expense
   amount: number; // Monetary amount of the expense


### PR DESCRIPTION
- Introduced `expenses_assigned_month` column to the expenses table with a comment for clarity.
- Added logic to populate `expenses_assigned_month` based on `date_from`, `date_to`, or `created_at`.
- Created a trigger and function to automatically set `expenses_assigned_month` for new records.
- Added `expense_month` and `expense_month_override` columns with corresponding logic for manual overrides.
- Updated API and components to utilize the new `expense_reporting_month` field for filtering and display.
- Enhanced utility functions and types to support the new expense reporting structure.